### PR TITLE
Fix: inheritance for enum fields

### DIFF
--- a/app/Espo/Core/Templates/Services/Hierarchy.php
+++ b/app/Espo/Core/Templates/Services/Hierarchy.php
@@ -898,6 +898,14 @@ class Hierarchy extends Record
             ->where(['children.id' => $entity->get('id')])
             ->find();
 
+        /*
+         * $entity might have been prepared using "prepareEntityForOutput".
+         * Without using the raw entity we might end up comparing optionIds with option labels.
+         */
+        $rawEntity = $this->getRepository()
+            ->where(['id' => $entity->get('id')])
+            ->findOne();
+
         if (empty($parents[0])) {
             return [];
         }
@@ -905,7 +913,7 @@ class Hierarchy extends Record
 
         $inheritedFields = [];
         foreach ($parents as $parent) {
-            $inheritedFields = array_merge($inheritedFields, $this->getInheritedFromParentFields($parent, $entity));
+            $inheritedFields = array_merge($inheritedFields, $this->getInheritedFromParentFields($parent, $rawEntity));
         }
 
         return $inheritedFields;
@@ -935,6 +943,5 @@ class Hierarchy extends Record
         }
 
         return $result;
-
     }
 }

--- a/app/Espo/Services/Record.php
+++ b/app/Espo/Services/Record.php
@@ -1041,7 +1041,10 @@ class Record extends \Espo\Core\Services\Base
             return $value;
         }
 
-        $key = array_search($value, $fieldDefs['options']);
+        $key = array_search($value, $fieldDefs['optionsIds']);
+        if ($key === false) {
+            $key = array_search($value, $fieldDefs['options']);
+        }
         if ($key === false) {
             if (!$validate) {
                 return '';


### PR DESCRIPTION
When trying to apply the parent value of an enum field an error like this popped up:

![image](https://github.com/atrocore/atrocore/assets/143341/11548fc6-c528-457a-9c89-a8cc69bd38b6)

The `modifyEnumValue` method expected the value to be the enum label. Not sure if it's a good fix to check `optionsIds` and `options` but when only using `optionsIds` I am unable to change the fields manually.

The other thing is similar: `getInheritedFields` compared ids and labels for inheritable enum fields and always showed them as changed.