### PR TITLE
Fix: ensure modules.json is regenerated if missing (#1317)

### DIFF
--- a/app/Atro/Composer/PostUpdate.php
+++ b/app/Atro/Composer/PostUpdate.php
@@ -269,7 +269,7 @@ class PostUpdate
      */
     private static function updateModulesList(): void
     {
-        if (self::isInstalled() && !self::isChanged()) {
+        if (self::isInstalled() && !self::isChanged() && file_exists('data/modules.json')) {
             return;
         }
 


### PR DESCRIPTION
**Title: Fix: ensure modules.json is regenerated if missing (#1317)**

**Issue:**
Modules were not appearing in the Modules -> Administration Panel list in certain scenarios. This occurred when the `data/modules.json` file was missing (e.g., deleted manually, excluded from git, or lost during deployment), but the system detected no changes in `composer.lock`. In this state, the system incorrectly assumed it didn't need to rebuild the module list.

Root Cause:
_`The _Atro\Composer\PostUpdate::updateModulesList_`_ method included an optimization to skip execution if the system was already installed and no composer changes were detected:

`**if (self::isInstalled() && !self::isChanged()) {
    return;
}**`

**This logic failed to check if the target artifact `data/modules.json` actually existed.**

**Solution:**
I updated the condition in `app/Atro/Composer/PostUpdate.php` to explicitly check for the existence of `data/modules.json.`

`**if (self::isInstalled() && !self::isChanged() && file_exists('data/modules.json')) {
    return;
}**`

Now, if `modules.json` is missing, the module list will be forced to regenerate, ensuring the Administration Panel always has the correct data.

Verification:

- Reproduction: Created a simulation script that mimicked the `isInstalled=true` and `isChanged=false` state with a missing `modules.json`. Validated that the original code skipped the update (leaving the file missing).

- Fix Validation: Verified that with the new change, the same script correctly triggered the `updateModulesList` logic and regenerated the file.

- Syntax Check: Passed `php -l` syntax check on the modified file.