### PR TITLE
Refactor setupActionItems to be the single source of truth for button…

### DIFF
--- a/client/src/views/layout-profile/record/detail.js
+++ b/client/src/views/layout-profile/record/detail.js
@@ -23,26 +23,24 @@ Espo.define('views/layout-profile/record/detail', 'views/record/detail', functio
         },
 
         setupActionItems() {
-            if (this.getUser().isAdmin()) {
-                if (!this.additionalButtons.find(b => b.name === 'menu')) {
-                    this.additionalButtons.push({
-                        name: "menu",
-                        label: this.translate("Menu", "labels", "LayoutProfile"),
-                        action: "editNavigation",
-                    })
-                }
+            Dep.prototype.setupActionItems.call(this);
 
-                if (!this.additionalButtons.find(b => b.name === 'dashboard')) {
-                    this.additionalButtons.push({
-                        name: "dashboard",
-                        label: this.translate("Dashboards", "labels", "LayoutProfile"),
-                        action: "editDashboard",
-                        cssStyle: "margin-left: 10px"
-                    });
-                }
+            if (this.getUser().isAdmin()) {
+                this.additionalButtons.push({
+                    name: "menu",
+                    label: this.translate("Menu", "labels", "LayoutProfile"),
+                    action: "editNavigation",
+                });
+
+                this.additionalButtons.push({
+                    name: "dashboard",
+                    label: this.translate("Dashboards", "labels", "LayoutProfile"),
+                    action: "editDashboard",
+                    cssStyle: "margin-left: 10px"
+                });
             }
 
-            if (this.getAcl().check(this.scope, 'edit') && !this.additionalButtons.find(b => b.name === 'favorites')) {
+            if (this.getAcl().check(this.scope, 'edit')) {
                 this.additionalButtons.push({
                     name: 'favorites',
                     label: this.translate('Favorites', 'labels', 'LayoutProfile'),
@@ -50,8 +48,6 @@ Espo.define('views/layout-profile/record/detail', 'views/record/detail', functio
                     cssStyle: "margin-left: 10px"
                 });
             }
-
-            Dep.prototype.setupActionItems.call(this);
         },
 
         actionEditNavigation: function () {

--- a/client/src/views/preview-template/record/detail.js
+++ b/client/src/views/preview-template/record/detail.js
@@ -11,26 +11,10 @@
 
 Espo.define('views/preview-template/record/detail', ['views/record/detail', 'views/search/search-filter-opener'],
     (Dep, SearchFilterOpener) => Dep.extend({
-        setupActionItems() {
-            Dep.prototype.setupActionItems.call(this);
-
-            let filterButton = {
-                tooltip: this.translate('openSearchFilter'),
-                action: 'openSearchFilter',
-                name: 'filterButton',
-                html: this.getFilterButtonHtml()
-            };
-
-            if(this.model.get('entityType')) {
-                this.additionalButtons.push(filterButton);
-            }
+        setup() {
+            Dep.prototype.setup.call(this);
 
             this.listenTo(this.model, 'sync', () => {
-                filterButton.html = this.getFilterButtonHtml();
-                this.additionalButtons = this.additionalButtons.filter(b => b.name !== filterButton.name);
-                if(this.model.get('entityType')) {
-                    this.additionalButtons.push(filterButton);
-                }
                 this.reRender();
             });
 
@@ -50,6 +34,19 @@ Espo.define('views/preview-template/record/detail', ['views/record/detail', 'vie
                     this.model.set('data', data);
                 }
             });
+        },
+
+        setupActionItems() {
+            Dep.prototype.setupActionItems.call(this);
+
+            if (this.model.get('entityType')) {
+                this.additionalButtons.push({
+                    tooltip: this.translate('openSearchFilter'),
+                    action: 'openSearchFilter',
+                    name: 'filterButton',
+                    html: this.getFilterButtonHtml()
+                });
+            }
         },
 
         getFilterButtonHtml() {

--- a/client/src/views/record/detail.js
+++ b/client/src/views/record/detail.js
@@ -608,6 +608,13 @@ Espo.define('views/record/detail', ['views/record/base', 'view-record-helper'], 
         },
 
         setupActionItems: function () {
+            this.buttonList = _.clone(this._initialButtonList);
+            this.buttonEditList = _.clone(this._initialButtonEditList);
+            this.dropdownItemList = _.clone(this._initialDropdownItemList);
+            this.dropdownEditItemList = _.clone(this._initialDropdownEditItemList);
+            this.additionalButtons = _.clone(this._initialAdditionalButtons);
+            this.additionalEditButtons = _.clone(this._initialAdditionalEditButtons);
+
             if (this.getMetadata().get(['scopes', this.model.name, 'disabled']) || this.getMetadata().get(['scopes', this.model.name, 'type']) === 'Archive') {
                 this.buttonList = []
                 this.dropdownItemList = []
@@ -691,22 +698,6 @@ Espo.define('views/record/detail', ['views/record/base', 'view-record-helper'], 
                     });
                 }
             }
-
-            let dropdownItemList = [];
-            (this.dropdownItemList || []).forEach(item => {
-                if (!item.name || item.name !== 'dynamicAction') {
-                    dropdownItemList.push(item);
-                }
-            });
-            this.dropdownItemList = dropdownItemList;
-
-            let additionalButtons = [];
-            (this.additionalButtons || []).forEach(item => {
-                if (!item.action || item.action !== 'dynamicAction') {
-                    additionalButtons.push(item);
-                }
-            });
-            this.additionalButtons = additionalButtons;
 
             if (this.selfAssignAction) {
                 if (
@@ -1404,6 +1395,13 @@ Espo.define('views/record/detail', ['views/record/base', 'view-record-helper'], 
                 label: 'Remove'
             }];
 
+            this._initialButtonList = _.clone(this.buttonList);
+            this._initialButtonEditList = _.clone(this.buttonEditList);
+            this._initialDropdownItemList = _.clone(this.dropdownItemList);
+            this._initialDropdownEditItemList = _.clone(this.dropdownEditItemList);
+            this._initialAdditionalButtons = _.clone(this.additionalButtons);
+            this._initialAdditionalEditButtons = _.clone(this.additionalEditButtons);
+
             this.isNew = this.model.isNew()
 
             this.setupBeforeFinal();
@@ -1412,7 +1410,7 @@ Espo.define('views/record/detail', ['views/record/base', 'view-record-helper'], 
                 this.setupActionItems();
                 window.dispatchEvent(new CustomEvent('record:buttons-update', { detail: this.getRecordButtons() }));
 
-                this.listenTo(this.model, 'sync', () => {
+                this.listenTo(this.model, 'sync after:save after:inlineEditSave', () => {
                     this.setupActionItems();
                     window.dispatchEvent(new CustomEvent('record:buttons-update', { detail: this.getRecordButtons() }));
                 });
@@ -2258,8 +2256,6 @@ Espo.define('views/record/detail', ['views/record/base', 'view-record-helper'], 
                 return null;
             }
 
-            this.cleanDuplicatedButtons();
-
             return {
                 buttons: this.buttonList,
                 editButtons: this.buttonEditList,
@@ -2268,24 +2264,6 @@ Espo.define('views/record/detail', ['views/record/base', 'view-record-helper'], 
                 additionalButtons: this.additionalButtons,
                 additionalEditButtons: this.additionalEditButtons,
             }
-        },
-
-        cleanDuplicatedButtons() {
-            let buttonTypes = ['additionalButtons', 'additionalEditButtons', 'dropdownItemList', 'dropdownEditItemList', 'buttonList', 'buttonEditList'];
-            buttonTypes.forEach((type) => {
-                if (!Array.isArray(this[type])) {
-                    return;
-                }
-                let existing = [];
-                this[type] = this[type].filter(el => {
-                    let code = el.action || el.name;
-                    if (!existing.includes(code)) {
-                        existing.push(code);
-                        return true;
-                    }
-                    return false;
-                });
-            });
         },
 
         convertDetailLayout: function (simplifiedLayout, el) {

--- a/client/src/views/storage/record/detail.js
+++ b/client/src/views/storage/record/detail.js
@@ -12,15 +12,13 @@ Espo.define('views/storage/record/detail', 'views/record/detail', Dep => {
 
     return Dep.extend({
 
-        setup() {
-            Dep.prototype.setup.call(this);
+        setupActionItems() {
+            Dep.prototype.setupActionItems.call(this);
 
-            this.additionalButtons = [
-                {
-                    "action": "scan",
-                    "label": this.translate('scan', 'labels', 'Storage')
-                }
-            ];
+            this.additionalButtons.push({
+                "action": "scan",
+                "label": this.translate('scan', 'labels', 'Storage')
+            });
         },
 
         actionScan() {


### PR DESCRIPTION
… state

- Capture initial button-list state in setup() via _initial* snapshots
- Reset all button arrays from snapshots at the start of setupActionItems()
- Remove now-redundant dynamicAction filter loops in setupActionItems()
- Move button setup from setup() into setupActionItems() for all subclasses
- Fix listener-leak in preview-template/record/detail.js
- Remove manual dedup guards in layout-profile and import-job detail views