### PR TITLE
Fix import_configurator_item names missed in V2Dot3Dot5 migration

### DIFF
--- a/app/Atro/Migrations/V2Dot3Dot10.php
+++ b/app/Atro/Migrations/V2Dot3Dot10.php
@@ -15,7 +15,6 @@ use Atro\Core\Migration\Base;
 use Atro\Core\Utils\Metadata;
 use Atro\Core\Utils\Util;
 use Atro\Core\Utils\IdGenerator;
-use Doctrine\DBAL\ParameterType;
 
 class V2Dot3Dot10 extends Base
 {
@@ -36,7 +35,6 @@ class V2Dot3Dot10 extends Base
         $this->migrateDataPipelines();
         $this->migrateProductGroup();
         $this->migrateLocaleDisableForUi();
-        $this->fixImportConfiguratorItemsMissedInV2Dot3Dot5();
     }
 
     public function migrateLocaleDisableForUi(): void
@@ -461,39 +459,6 @@ class V2Dot3Dot10 extends Base
         }
 
         return $this->metadata;
-    }
-
-    private function fixImportConfiguratorItemsMissedInV2Dot3Dot5(): void
-    {
-        // Extend the V2Dot3Dot5 system_name rename to import_configurator_item.name.
-        // Fix items where name starts with the attribute ID (the fallback prefix when code was empty).
-        try {
-            $items = $this->getDbal()->createQueryBuilder()
-                ->select('i.id', 'i.name', 'i.entity_attribute_id', 'a.system_name')
-                ->from('import_configurator_item', 'i')
-                ->innerJoin('i', 'attribute', 'a', 'a.id = i.entity_attribute_id AND a.deleted = :false')
-                ->where('i.deleted = :false')
-                ->andWhere('a.system_name IS NOT NULL')
-                ->setParameter('false', false, ParameterType::BOOLEAN)
-                ->fetchAllAssociative();
-
-            foreach ($items as $item) {
-                if (!str_starts_with($item['name'], $item['entity_attribute_id'])) {
-                    continue;
-                }
-
-                $newName = $item['system_name'] . substr($item['name'], strlen($item['entity_attribute_id']));
-
-                $this->getDbal()->createQueryBuilder()
-                    ->update('import_configurator_item')
-                    ->set('name', ':name')
-                    ->where('id = :id')
-                    ->setParameter('name', $newName)
-                    ->setParameter('id', $item['id'])
-                    ->executeStatement();
-            }
-        } catch (\Throwable $e) {
-        }
     }
 
     private function exec(string $sql): void

--- a/app/Atro/Migrations/V2Dot3Dot10.php
+++ b/app/Atro/Migrations/V2Dot3Dot10.php
@@ -15,6 +15,7 @@ use Atro\Core\Migration\Base;
 use Atro\Core\Utils\Metadata;
 use Atro\Core\Utils\Util;
 use Atro\Core\Utils\IdGenerator;
+use Doctrine\DBAL\ParameterType;
 
 class V2Dot3Dot10 extends Base
 {
@@ -35,6 +36,7 @@ class V2Dot3Dot10 extends Base
         $this->migrateDataPipelines();
         $this->migrateProductGroup();
         $this->migrateLocaleDisableForUi();
+        $this->fixImportConfiguratorItemsMissedInV2Dot3Dot5();
     }
 
     public function migrateLocaleDisableForUi(): void
@@ -459,6 +461,39 @@ class V2Dot3Dot10 extends Base
         }
 
         return $this->metadata;
+    }
+
+    private function fixImportConfiguratorItemsMissedInV2Dot3Dot5(): void
+    {
+        // Extend the V2Dot3Dot5 system_name rename to import_configurator_item.name.
+        // Fix items where name starts with the attribute ID (the fallback prefix when code was empty).
+        try {
+            $items = $this->getDbal()->createQueryBuilder()
+                ->select('i.id', 'i.name', 'i.entity_attribute_id', 'a.system_name')
+                ->from('import_configurator_item', 'i')
+                ->innerJoin('i', 'attribute', 'a', 'a.id = i.entity_attribute_id AND a.deleted = :false')
+                ->where('i.deleted = :false')
+                ->andWhere('a.system_name IS NOT NULL')
+                ->setParameter('false', false, ParameterType::BOOLEAN)
+                ->fetchAllAssociative();
+
+            foreach ($items as $item) {
+                if (!str_starts_with($item['name'], $item['entity_attribute_id'])) {
+                    continue;
+                }
+
+                $newName = $item['system_name'] . substr($item['name'], strlen($item['entity_attribute_id']));
+
+                $this->getDbal()->createQueryBuilder()
+                    ->update('import_configurator_item')
+                    ->set('name', ':name')
+                    ->where('id = :id')
+                    ->setParameter('name', $newName)
+                    ->setParameter('id', $item['id'])
+                    ->executeStatement();
+            }
+        } catch (\Throwable $e) {
+        }
     }
 
     private function exec(string $sql): void

--- a/app/Atro/Migrations/V2Dot3Dot5.php
+++ b/app/Atro/Migrations/V2Dot3Dot5.php
@@ -1467,6 +1467,7 @@ class V2Dot3Dot5 extends Base
 
                         $oldCode = $sn !== '' ? $sn : $row['id'];
                         $this->fixExportConfiguratorItems($row['id'], $oldCode, $candidate);
+                        $this->fixImportConfiguratorItems($row['id'], $oldCode, $candidate);
 
                         foreach ($checkRules as $k => $checkRule) {
                             if (empty($checkRule['attributeId']) || $checkRule['attributeId'] !== $row['id']) {
@@ -1543,6 +1544,39 @@ class V2Dot3Dot5 extends Base
 
                 $this->getDbal()->createQueryBuilder()
                     ->update('export_configurator_item')
+                    ->set('name', ':name')
+                    ->where('id = :id')
+                    ->setParameter('name', $newPrefix . substr($item['name'], strlen($oldPrefix)))
+                    ->setParameter('id', $item['id'])
+                    ->executeStatement();
+            }
+        } catch (\Throwable $e) {
+        }
+    }
+
+    private function fixImportConfiguratorItems(string $attributeId, string $oldPrefix, string $newPrefix): void
+    {
+        if ($oldPrefix === $newPrefix) {
+            return;
+        }
+
+        try {
+            $items = $this->getDbal()->createQueryBuilder()
+                ->select('id', 'name')
+                ->from('import_configurator_item')
+                ->where('entity_attribute_id = :attributeId')
+                ->andWhere('deleted = :false')
+                ->setParameter('attributeId', $attributeId)
+                ->setParameter('false', false, ParameterType::BOOLEAN)
+                ->fetchAllAssociative();
+
+            foreach ($items as $item) {
+                if (!str_starts_with($item['name'], $oldPrefix)) {
+                    continue;
+                }
+
+                $this->getDbal()->createQueryBuilder()
+                    ->update('import_configurator_item')
                     ->set('name', ':name')
                     ->where('id = :id')
                     ->setParameter('name', $newPrefix . substr($item['name'], strlen($oldPrefix)))


### PR DESCRIPTION
V2Dot3Dot5 updated attribute.system_name but did not update import_configurator_item.name.
- V2Dot3Dot5: add fixImportConfiguratorItems alongside the existing fixExportConfiguratorItems call
- V2Dot3Dot10: fix items where name starts with the attribute ID (catch-up for clients already on 2.3.5)