### PR TITLE
Harden handling of the phpBinPath config parameter

### DIFF
--- a/app/Atro/Composer/PostUpdate.php
+++ b/app/Atro/Composer/PostUpdate.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Atro\Composer;
 
+use Atro\Console\AbstractConsole;
 use Atro\Core\Container;
 use Atro\Core\Application as App;
 use Atro\Jobs\MassDownload;
@@ -938,19 +939,7 @@ class PostUpdate
 
     private static function getPhpBin(): string
     {
-        if (self::$container->get('config')->get('phpBinPath')) {
-            return self::$container->get('config')->get('phpBinPath');
-        }
-
-        if (isset($_SERVER['PHP_PATH']) && !empty($_SERVER['PHP_PATH'])) {
-            return $_SERVER['PHP_PATH'];
-        }
-
-        if (!empty($_SERVER['_'])) {
-            return $_SERVER['_'];
-        }
-
-        return defined("PHP_BINDIR") ? PHP_BINDIR . DIRECTORY_SEPARATOR . 'php' : 'php';
+        return AbstractConsole::getPhpBinPath(self::$container->get('config'));
     }
 
     private static function isInstalled(): bool

--- a/app/Atro/Console/AbstractConsole.php
+++ b/app/Atro/Console/AbstractConsole.php
@@ -62,16 +62,21 @@ abstract class AbstractConsole
 
     public static function getPhpBinPath(Config $config): string
     {
-        if ($config->get('phpBinPath')) {
-            return $config->get('phpBinPath');
-        }
+        $candidates = [
+            $config->get('phpBinPath'),
+            $_SERVER['PHP_PATH'] ?? null,
+            $_SERVER['_'] ?? null,
+        ];
 
-        if (isset($_SERVER['PHP_PATH']) && !empty($_SERVER['PHP_PATH'])) {
-            return $_SERVER['PHP_PATH'];
-        }
+        foreach ($candidates as $candidate) {
+            // the value ends up in a shell command, so only an existing executable file is accepted
+            if (!empty($candidate) && is_file($candidate) && is_executable($candidate)) {
+                return $candidate;
+            }
 
-        if (!empty($_SERVER['_'])) {
-            return $_SERVER['_'];
+            if (!empty($candidate) && isset($GLOBALS['log'])) {
+                $GLOBALS['log']->warning("PHP binary '$candidate' is not an executable file, so it was ignored.");
+            }
         }
 
         return defined("PHP_BINDIR") ? PHP_BINDIR . DIRECTORY_SEPARATOR . 'php' : 'php';

--- a/app/Atro/Core/Utils/Config.php
+++ b/app/Atro/Core/Utils/Config.php
@@ -41,6 +41,7 @@ class Config extends \Espo\Core\Utils\Config
             'userLimit',
             'stylesheet',
             'userItems',
+            'phpBinPath',
         ],
         'adminItems'                => [
             'devMode',

--- a/app/Atro/Services/Variable.php
+++ b/app/Atro/Services/Variable.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Atro\Services;
 
 use Atro\Core\Exceptions\BadRequest;
+use Atro\Core\Exceptions\Forbidden;
 use Atro\Core\Exceptions\NotFound;
 use Espo\Core\Services\Base;
 
@@ -68,7 +69,7 @@ class Variable extends Base
         if (!preg_match('/^[a-z][a-zA-Z0-9]*$/', $key)) {
             throw new BadRequest($this->getInjection('language')->translate('variableKeyInvalid', 'exceptions', 'Settings'));
         }
-        if ($key === 'variables' || $this->getConfig()->has($key)) {
+        if ($key === 'variables' || in_array($key, $this->getRestrictedKeys()) || $this->getConfig()->has($key)) {
             throw new BadRequest(sprintf($this->getInjection('language')->translate('variableKeyIsExist', 'exceptions', 'Settings'), $key));
         }
 
@@ -103,6 +104,11 @@ class Variable extends Base
         $variables = $this->getConfig()->get('variables', []);
         if (!in_array($id, $variables)) {
             throw new NotFound();
+        }
+
+        // such a variable could only be created before the restriction was introduced, so it can be deleted but not changed
+        if (in_array($id, $this->getRestrictedKeys())) {
+            throw new Forbidden();
         }
 
         if (property_exists($data, 'value')) {
@@ -149,5 +155,18 @@ class Variable extends Base
         $this->getConfig()->save();
 
         return true;
+    }
+
+    /**
+     * A variable must never shadow a protected config parameter, because Config::set() bypasses
+     * the systemItems/adminItems restrictions that Settings::update() relies on
+     */
+    protected function getRestrictedKeys(): array
+    {
+        return array_merge(
+            $this->getConfig()->get('systemItems', []),
+            $this->getConfig()->get('adminItems', []),
+            $this->getConfig()->get('userItems', [])
+        );
     }
 }


### PR DESCRIPTION
`config.phpBinPath` is used to build the command that runs `atrocore-installer.phar`                                                                                                                                                                              
  (`PostUpdate`, `Daemon`, `CheckUpdates`), but it was accepted as-is and could be modified                                                                                                                                                                         
  through more API paths than intended. This makes its handling stricter and consistent.                                                                                                                                                                            
                                                                                                                                                                                                                                                                    
  - `Core/Utils/Config.php` — `phpBinPath` is now an internal parameter (`systemItems`).                                                                                                                                                                            
  - `Services/Variable.php` — a variable can no longer shadow an internal config parameter:                                                                                                                                                                         
    `Config::set()` bypasses the `systemItems`/`adminItems` restrictions that                                                                                                                                                                                       
    `Settings::update()` relies on. Existing such variables can be deleted but not changed.                                                                                                                                                                         
  - `Console/AbstractConsole.php` — `getPhpBinPath()` accepts a candidate only if it points                                                                                                                                                                         
    to an existing executable file, otherwise it falls back to the next candidate and                                                                                                                                                                               
    finally to `PHP_BINDIR/php`. A rejected value is logged as a warning.                                                                                                                                                                                           
  - `Composer/PostUpdate.php` — uses `AbstractConsole::getPhpBinPath()` instead of its own                                                                                                                                                                          
    duplicated copy.