### PR TITLE
Support mass actions for Update actions targeting other entities via …

### DIFF
--- a/app/Atro/ActionTypes/AbstractAction.php
+++ b/app/Atro/ActionTypes/AbstractAction.php
@@ -69,7 +69,7 @@ abstract class AbstractAction implements TypeInterface
             if (empty($sourceEntity)) {
                 return true;
             }
-            $raw = $action->get('conditions');
+            $raw        = $action->get('conditions');
             $conditions = is_string($raw) ? @json_decode($raw, true) : @json_decode(@json_encode($raw), true);
             if (!empty($conditions)) {
                 if ($sourceEntity->getEntityType() !== $action->get('sourceEntity')) {
@@ -102,7 +102,7 @@ abstract class AbstractAction implements TypeInterface
          *
          */
         if ($action->get('conditionsType') === 'script') {
-            $template = (string)($action->get('conditionsScript') ?? '');
+            $template     = (string)($action->get('conditionsScript') ?? '');
             $templateData = [
                 'entity'          => $this->getSourceEntity($action, $input),
                 'triggeredEntity' => $input->triggeredEntity ?? null,
@@ -192,7 +192,10 @@ abstract class AbstractAction implements TypeInterface
 
     protected function getWhere(Entity $action): ?array
     {
-        return !empty($action->get('data')->where) ? $action->get('data')->where : null;
+        if (!empty($action->get('data')->where)) {
+            return json_decode(json_encode($action->get('data')->where), true);
+        }
+        return null;
     }
 
     public function getServiceFactory(): ServiceFactory

--- a/app/Atro/ActionTypes/AbstractBulkAction.php
+++ b/app/Atro/ActionTypes/AbstractBulkAction.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * AtroCore Software
+ *
+ * This source file is available under GNU General Public License version 3 (GPLv3).
+ * Full copyright and license information is available in LICENSE.txt, located in the root directory.
+ *
+ * @copyright  Copyright (c) AtroCore GmbH (https://www.atrocore.com)
+ * @license    GPLv3 (https://www.gnu.org/licenses/)
+ */
+
+declare(strict_types=1);
+
+namespace Atro\ActionTypes;
+
+use Atro\Core\Exceptions\BadRequest;
+use Atro\Entities\ActionExecution;
+use Espo\ORM\Entity;
+
+/**
+ * Base for action types that either act on one preselected record (applyToPreselectedRecords)
+ * or on every record matching the action's filter. Filter-driven runs that match more than
+ * massUpdateMaxCountWithoutJob records are handed off to the generic Atro\Jobs\MassActionCreator,
+ * which splits the matched set into per-chunk Atro\Jobs\ActionHandler jobs - the same chunking
+ * mechanism used for mass-updates, reused here instead of reimplemented.
+ */
+abstract class AbstractBulkAction extends AbstractAction
+{
+    /**
+     * Perform the actual per-record operation. May throw - runForEntity() logs it and continues.
+     * $log is the ActionExecutionLog being built for this entity - set its 'type'/'message'
+     * to override the default outcome-based values runForEntity() would otherwise apply.
+     */
+    abstract protected function processEntity(Entity $entity, Entity $log): bool;
+
+    public function useMassActions(Entity $action, \stdClass $input): bool
+    {
+        return !empty($action->get('applyToPreselectedRecords'));
+    }
+
+    public function execute(ActionExecution $execution, \stdClass $input): bool
+    {
+        $action       = $execution->get('action');
+        $sourceEntity = $this->getSourceEntity($action, $input);
+
+        if (empty($action->get('applyToPreselectedRecords'))) {
+            $entityType = $action->get('searchEntity');
+            $where      = $this->getWhere($action) ?? [];
+
+            $selectManager = $this->container->get('selectManagerFactory')->create($entityType);
+            $repository    = $this->getEntityManager()->getRepository($entityType);
+            $selectParams  = $selectManager->getSelectParams(['where' => $where], true, true);
+            $repository->handleSelectParams($selectParams);
+            $count = $repository->count($selectParams);
+
+            if ($count === 0) {
+                $execution->set('status', 'done');
+                $this->getEntityManager()->saveEntity($execution);
+
+                return true;
+            }
+
+            if ($count > $this->getConfig()->get('massUpdateMaxCountWithoutJob', 200)) {
+                $this->dispatchChunkCreatorJob($action, $execution, $entityType, $where, $count);
+
+                return true;
+            }
+
+            $collection = $repository->find($selectParams);
+
+            foreach ($collection as $entity) {
+                $this->runForEntity($entity, $execution);
+            }
+
+            $execution->set('status', 'done');
+            $this->getEntityManager()->saveEntity($execution);
+
+            return true;
+        }
+
+        if (empty($sourceEntity)) {
+            throw new BadRequest('Action can be executed only from Source Entity.');
+        }
+
+        $result = $this->runForEntity($sourceEntity, $execution);
+
+        $execution->set('status', 'done');
+        $this->getEntityManager()->saveEntity($execution);
+
+        return $result;
+    }
+
+    /**
+     * Process one entity against a (possibly shared, across a chunk) ActionExecution, logging
+     * the outcome via ActionExecutionLog. Public so Atro\Jobs\ActionHandler can call it directly
+     * for each id in a chunk, reusing one execution/its logs instead of creating a fresh
+     * execution per record.
+     */
+    public function runForEntity(Entity $entity, ActionExecution $execution): bool
+    {
+        $log = $this->getEntityManager()->getRepository('ActionExecutionLog')->get();
+        $log->set([
+            'actionExecutionId' => $execution->get('id'),
+            'entityName'        => $entity->getEntityName(),
+            'entityId'          => $entity->get('id'),
+        ]);
+
+        try {
+            $result = $this->processEntity($entity, $log);
+            if (empty($log->get('type'))) {
+                $log->set('type', $result ? 'update' : 'error');
+            }
+            if (!$result && empty($log->get('message'))) {
+                $log->set('message', 'Action was not applicable to this record.');
+            }
+        } catch (\Throwable $e) {
+            $result = false;
+            if (empty($log->get('type'))) {
+                $log->set('type', 'error');
+            }
+            if (empty($log->get('message'))) {
+                $log->set('message', $e->getMessage());
+            }
+        }
+
+        $this->getEntityManager()->saveEntity($log);
+
+        return $result;
+    }
+
+    protected function dispatchChunkCreatorJob(Entity $action, ActionExecution $execution, string $entityType, array $where, int $total): void
+    {
+        $maxConcurrentJobs = $this->getConfig()->get('maxConcurrentJobs', 6);
+        $maxChunkSize      = $this->getConfig()->get('massUpdateMaxChunkSize', 3000);
+        $minChunkSize      = $this->getConfig()->get('massUpdateMinChunkSize', 400);
+        $chunkSize         = \Atro\Services\Record::getChunkSize($total, $maxChunkSize, $minChunkSize, $maxConcurrentJobs);
+
+        $jobEntity = $this->getEntityManager()->getEntity('Job');
+        $jobEntity->set([
+            'name'    => 'Create chunk jobs: ' . $action->get('name'),
+            'type'    => 'MassActionCreator',
+            'payload' => [
+                'entityName' => $entityType,
+                'action'     => 'action',
+                'total'      => $total,
+                'chunkSize'  => $chunkSize,
+                'params'     => [
+                    'where'             => $where,
+                    'additionalJobData' => [
+                        'actionId'          => $action->get('id'),
+                        'actionExecutionId' => $execution->get('id'),
+                        'sourceEntity'      => $action->get('sourceEntity'),
+                    ],
+                ],
+            ],
+        ]);
+        $this->getEntityManager()->saveEntity($jobEntity);
+    }
+}

--- a/app/Atro/ActionTypes/Update.php
+++ b/app/Atro/ActionTypes/Update.php
@@ -231,6 +231,14 @@ class Update extends AbstractAction
 
     public function useMassActions(Entity $action, \stdClass $input): bool
     {
-        return false;
+        $where = $this->getWhere($action);
+        if (empty($where)) {
+            return false;
+        }
+
+        // if the where clause references the triggering entity (e.g. {{ entity.id }}), it's computed
+        // differently for every selected source record, so each one must be processed individually
+        // rather than resolving target records via a single combined query
+        return (bool)preg_match('/\{\{\s*entity\b/', json_encode($where));
     }
 }

--- a/app/Atro/Jobs/Action.php
+++ b/app/Atro/Jobs/Action.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * AtroCore Software
+ *
+ * This source file is available under GNU General Public License version 3 (GPLv3).
+ * Full copyright and license information is available in LICENSE.txt, located in the root directory.
+ *
+ * @copyright  Copyright (c) AtroCore GmbH (https://www.atrocore.com)
+ * @license    GPLv3 (https://www.gnu.org/licenses/)
+ */
+
+declare(strict_types=1);
+
+namespace Atro\Jobs;
+
+use Atro\Entities\Job;
+
+class Action extends AbstractJob implements JobInterface
+{
+    public function run(Job $job): void
+    {
+        $scheduledJob = $this->getEntityManager()->getEntity('ScheduledJob', $job->get('scheduledJobId'));
+        if (empty($scheduledJob)) {
+            return;
+        }
+
+        $actionId = $scheduledJob->get('actionId');
+        if (empty($actionId)) {
+            return;
+        }
+
+        $input = new \stdClass();
+        $input->executedViaScheduledJob = true;
+        $input->job = $job;
+
+        $this->getServiceFactory()->create('Action')->executeNow($actionId, $input);
+    }
+}

--- a/app/Atro/Jobs/ActionHandler.php
+++ b/app/Atro/Jobs/ActionHandler.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Atro\Jobs;
 
+use Atro\ActionTypes\AbstractBulkAction;
 use Atro\Core\ActionManager;
 use Atro\Entities\Job;
 
@@ -37,6 +38,32 @@ class ActionHandler extends AbstractJob implements JobInterface
             return;
         }
 
+        // a chunk of a shared bulk execution (dispatched by an AbstractBulkAction) - reuse the
+        // one ActionExecution/its logs instead of creating a fresh execution per id
+        if (!empty($data['actionExecutionId'])) {
+            $execution = $this->getEntityManager()->getRepository('ActionExecution')->get($data['actionExecutionId']);
+            $actionType = $this->getActionType($action->get('type'));
+
+            if (!empty($execution) && $actionType instanceof AbstractBulkAction) {
+                $repository = $this->getEntityManager()->getRepository($data['entityType'] ?? $action->get('searchEntity'));
+
+                foreach ($data['ids'] as $id) {
+                    $entity = $repository->get($id);
+                    if (empty($entity)) {
+                        continue;
+                    }
+
+                    try {
+                        $actionType->runForEntity($entity, $execution);
+                    } catch (\Throwable $e) {
+                        $GLOBALS['log']->error("Mass {$action->get('type')} Action failed for '$id': " . $e->getMessage());
+                    }
+                }
+
+                return;
+            }
+        }
+
         foreach ($data['ids'] as $id) {
             $input = new \stdClass();
             $input->executedViaScheduledJob = true;
@@ -51,6 +78,13 @@ class ActionHandler extends AbstractJob implements JobInterface
                 $GLOBALS['log']->error("Mass $typeName Action failed: " . $e->getMessage());
             }
         }
+    }
+
+    protected function getActionType(string $type)
+    {
+        $className = $this->getMetadata()->get(['action', 'types', $type]);
+
+        return empty($className) ? null : $this->getContainer()->get($className);
     }
 
     protected function getActionManager(): ActionManager

--- a/app/Atro/Migrations/V2Dot3Dot17.php
+++ b/app/Atro/Migrations/V2Dot3Dot17.php
@@ -1,0 +1,49 @@
+<?php
+/*
+ * AtroCore Software
+ *
+ * This source file is available under GNU General Public License version 3 (GPLv3).
+ * Full copyright and license information is available in LICENSE.txt, located in the root directory.
+ *
+ * @copyright  Copyright (c) AtroCore GmbH (https://www.atrocore.com)
+ * @license    GPLv3 (https://www.gnu.org/licenses/)
+ */
+
+namespace Atro\Migrations;
+
+use Atro\Core\Migration\Base;
+
+class V2Dot3Dot17 extends Base
+{
+    public function getMigrationDateTime(): ?\DateTime
+    {
+        return new \DateTime('2026-08-25 12:00:00');
+    }
+
+    public function up(): void
+    {
+        $fromSchema = $this->getCurrentSchema();
+        $toSchema = clone $fromSchema;
+
+        if ($toSchema->hasTable('scheduled_job')) {
+            $table = $toSchema->getTable('scheduled_job');
+
+            if (!$table->hasColumn('action_id')) {
+                $table->addColumn('action_id', 'string', ['length' => 36, 'notnull' => false]);
+                $table->addIndex(['action_id', 'deleted'], 'IDX_SCHEDULED_JOB_ACTION_ID');
+
+                foreach ($this->schemasDiffToSql($fromSchema, $toSchema) as $sql) {
+                    $this->exec($sql);
+                }
+            }
+        }
+    }
+
+    protected function exec(string $sql): void
+    {
+        try {
+            $this->getPDO()->exec($sql);
+        } catch (\Throwable $e) {
+        }
+    }
+}

--- a/app/Atro/Resources/i18n/cs_CZ/ScheduledJob.json
+++ b/app/Atro/Resources/i18n/cs_CZ/ScheduledJob.json
@@ -2,7 +2,11 @@
   "fields": {
     "name": "Jméno",
     "scheduling": "Plánování",
-    "jobs": "Úlohy"
+    "jobs": "Úlohy",
+    "action": "Akce"
+  },
+  "links": {
+    "action": "Akce"
   },
   "labels": {
     "executeNow": "Provést nyní"
@@ -25,7 +29,8 @@
       "FindMatches": "Vyhledávání shod",
       "CalculateScriptFieldsForEntities": "Výpočet polí skriptu",
       "SendReports": "Odesílání anonymních chybových hlášení",
-      "CreateClusters": "Vytváření klastrů"
+      "CreateClusters": "Vytváření klastrů",
+      "Action": "Akce"
     }
   },
   "tooltips": {

--- a/app/Atro/Resources/i18n/de_DE/ScheduledJob.json
+++ b/app/Atro/Resources/i18n/de_DE/ScheduledJob.json
@@ -2,7 +2,11 @@
   "fields": {
     "scheduling": "Planung",
     "jobs": "Aufträge",
-    "name": "Name"
+    "name": "Name",
+    "action": "Aktion"
+  },
+  "links": {
+    "action": "Aktion"
   },
   "labels": {
     "executeNow": "Jetzt ausführen"
@@ -21,7 +25,8 @@
       "FindMatches": "Treffer finden",
       "CalculateScriptFieldsForEntities": "Skriptfelder berechnen",
       "SendReports": "Anonyme Fehlerberichte senden",
-      "CreateClusters": "Cluster erstellen"
+      "CreateClusters": "Cluster erstellen",
+      "Action": "Aktion"
     }
   },
   "tooltips": {

--- a/app/Atro/Resources/i18n/en_US/ScheduledJob.json
+++ b/app/Atro/Resources/i18n/en_US/ScheduledJob.json
@@ -2,7 +2,11 @@
   "fields": {
     "name": "Name",
     "scheduling": "Scheduling",
-    "jobs": "Jobs"
+    "jobs": "Jobs",
+    "action": "Action"
+  },
+  "links": {
+    "action": "Action"
   },
   "labels": {
     "executeNow": "Execute Now"
@@ -25,7 +29,8 @@
       "FindMatches": "Find matches",
       "CalculateScriptFieldsForEntities": "Calculate script fields",
       "SendReports": "Send anonymous error reports",
-      "CreateClusters": "Create Clusters"
+      "CreateClusters": "Create Clusters",
+      "Action": "Action"
     }
   },
   "tooltips": {

--- a/app/Atro/Resources/i18n/es_ES/ScheduledJob.json
+++ b/app/Atro/Resources/i18n/es_ES/ScheduledJob.json
@@ -2,7 +2,11 @@
   "fields": {
     "name": "Nombre",
     "scheduling": "Programación",
-    "jobs": "Trabajos"
+    "jobs": "Trabajos",
+    "action": "Acción"
+  },
+  "links": {
+    "action": "Acción"
   },
   "labels": {
     "executeNow": "Ejecutar ahora"
@@ -25,7 +29,8 @@
       "FindMatches": "Buscar coincidencias",
       "CalculateScriptFieldsForEntities": "Calcular campos de script",
       "SendReports": "Enviar informes de error anónimos",
-      "CreateClusters": "Crear agrupaciones"
+      "CreateClusters": "Crear agrupaciones",
+      "Action": "Acción"
     }
   },
   "tooltips": {

--- a/app/Atro/Resources/i18n/fr_FR/ScheduledJob.json
+++ b/app/Atro/Resources/i18n/fr_FR/ScheduledJob.json
@@ -2,7 +2,11 @@
   "fields": {
     "name": "Nom",
     "scheduling": "Programmation",
-    "jobs": "Tâches"
+    "jobs": "Tâches",
+    "action": "Action"
+  },
+  "links": {
+    "action": "Action"
   },
   "labels": {
     "executeNow": "Exécuter maintenant"
@@ -25,7 +29,8 @@
       "FindMatches": "Recherce de correspondances",
       "CalculateScriptFieldsForEntities": "Calcule des champs scripts",
       "SendReports": "Envoie des rapports d'erreur anonymes",
-      "CreateClusters": "Créer des clusters"
+      "CreateClusters": "Créer des clusters",
+      "Action": "Action"
     }
   },
   "tooltips": {

--- a/app/Atro/Resources/i18n/it_IT/ScheduledJob.json
+++ b/app/Atro/Resources/i18n/it_IT/ScheduledJob.json
@@ -2,7 +2,11 @@
   "fields": {
     "name": "Nome",
     "scheduling": "Programmazione",
-    "jobs": "Offerte di lavoro"
+    "jobs": "Offerte di lavoro",
+    "action": "Azione"
+  },
+  "links": {
+    "action": "Azione"
   },
   "labels": {
     "executeNow": "Eseguire ora"
@@ -25,7 +29,8 @@
       "FindMatches": "Trova le corrispondenze",
       "CalculateScriptFieldsForEntities": "Calcola i campi dello script",
       "SendReports": "Inviare segnalazioni di errore anonime",
-      "CreateClusters": "Creare cluster"
+      "CreateClusters": "Creare cluster",
+      "Action": "Azione"
     }
   },
   "tooltips": {

--- a/app/Atro/Resources/i18n/pl_PL/ScheduledJob.json
+++ b/app/Atro/Resources/i18n/pl_PL/ScheduledJob.json
@@ -2,7 +2,11 @@
   "fields": {
     "name": "Nazwa",
     "scheduling": "Harmonogram",
-    "jobs": "Zadania"
+    "jobs": "Zadania",
+    "action": "Akcja"
+  },
+  "links": {
+    "action": "Akcja"
   },
   "labels": {
     "executeNow": "Wykonaj teraz"
@@ -25,7 +29,8 @@
       "FindMatches": "Proszę znaleźć dopasowania",
       "CalculateScriptFieldsForEntities": "Obliczanie pól skryptu",
       "SendReports": "Wysyłanie anonimowych raportów o błędach",
-      "CreateClusters": "Tworzenie klastrów"
+      "CreateClusters": "Tworzenie klastrów",
+      "Action": "Akcja"
     }
   },
   "tooltips": {

--- a/app/Atro/Resources/i18n/ru_RU/ScheduledJob.json
+++ b/app/Atro/Resources/i18n/ru_RU/ScheduledJob.json
@@ -2,7 +2,11 @@
   "fields": {
     "name": "Название",
     "scheduling": "Планирование",
-    "jobs": "Задания"
+    "jobs": "Задания",
+    "action": "Действие"
+  },
+  "links": {
+    "action": "Действие"
   },
   "exceptions": {
     "wrongCrontabConfiguration": "Неправильная конфигурация crontab",
@@ -18,7 +22,8 @@
       "CalculateScriptFieldsForEntities": "Вычислите поля сценария",
       "FindMatches": "Найдите соответствия",
       "SendReports": "Отправлять анонимные отчеты об ошибках",
-      "CreateClusters": "Создавайте кластеры"
+      "CreateClusters": "Создавайте кластеры",
+      "Action": "Действие"
     }
   },
   "tooltips": {

--- a/app/Atro/Resources/i18n/uk_UA/ScheduledJob.json
+++ b/app/Atro/Resources/i18n/uk_UA/ScheduledJob.json
@@ -2,7 +2,11 @@
   "fields": {
     "name": "Назва",
     "scheduling": "Планування",
-    "jobs": "Завдання"
+    "jobs": "Завдання",
+    "action": "Дія"
+  },
+  "links": {
+    "action": "Дія"
   },
   "labels": {
     "executeNow": "Виконати зараз"
@@ -21,7 +25,8 @@
       "FindMatches": "Знайти збіги",
       "CalculateScriptFieldsForEntities": "Обчислити поля скриптів",
       "SendReports": "Надсилати анонімні повідомлення про помилки",
-      "CreateClusters": "Створити кластери"
+      "CreateClusters": "Створити кластери",
+      "Action": "Дія"
     }
   },
   "tooltips": {

--- a/app/Atro/Resources/metadata/app/jobTypes.json
+++ b/app/Atro/Resources/metadata/app/jobTypes.json
@@ -76,6 +76,10 @@
     "scheduledJob": false,
     "handler": "\\Atro\\Jobs\\ActionHandler"
   },
+  "Action": {
+    "scheduledJob": true,
+    "handler": "\\Atro\\Jobs\\Action"
+  },
   "ExecuteAction": {
     "scheduledJob": false,
     "handler": "\\Atro\\Jobs\\ExecuteAction"

--- a/app/Atro/Resources/metadata/entityDefs/ScheduledJob.json
+++ b/app/Atro/Resources/metadata/entityDefs/ScheduledJob.json
@@ -75,6 +75,29 @@
         }
       }
     },
+    "action": {
+      "type": "link",
+      "conditionalProperties": {
+        "visible": {
+          "conditionGroup": [
+            {
+              "type": "equals",
+              "attribute": "type",
+              "value": "Action"
+            }
+          ]
+        },
+        "required": {
+          "conditionGroup": [
+            {
+              "type": "equals",
+              "attribute": "type",
+              "value": "Action"
+            }
+          ]
+        }
+      }
+    },
     "jobs": {
       "type": "linkMultiple"
     }
@@ -96,6 +119,10 @@
     "storage": {
       "type": "belongsTo",
       "entity": "Storage"
+    },
+    "action": {
+      "type": "belongsTo",
+      "entity": "Action"
     }
   },
   "collection": {

--- a/app/Atro/Services/ActionExecution.php
+++ b/app/Atro/Services/ActionExecution.php
@@ -32,8 +32,8 @@ class ActionExecution extends Base
             $entity->set('action', $action);
             $entity->set('actionName', $action->get('name'));
 
-            if (in_array($action->get('type'), ['create', 'update', 'createOrUpdate', 'createRendition'])) {
-                $entity->set('listScope', $action->get('targetEntity') ??  $action->get('sourceEntity'));
+            if (in_array($action->get('type'), array_merge(['create', 'update', 'createOrUpdate', 'createRendition'], array_keys($this->getMetadata()->get(['action', 'filterableTypes'], []))))) {
+                $entity->set('listScope', $action->get('targetEntity') ?? $action->get('sourceEntity'));
                 $this->getRepository()->prepareCount($entity, 'createdCount');
                 $this->getRepository()->prepareCount($entity, 'updatedCount');
                 $this->getRepository()->prepareCount($entity, 'failedCount');

--- a/client/src/views/action/record/detail.js
+++ b/client/src/views/action/record/detail.js
@@ -67,7 +67,9 @@ Espo.define('views/action/record/detail', ['views/record/detail', 'views/record/
         },
 
         getAllowedActionTypes() {
-            return ['update', 'delete', 'email'];
+            return ['update', 'delete', 'email'].concat(
+                Object.keys(this.getMetadata().get(['action', 'filterableTypes']) || {})
+            );
         }
     })
 );

--- a/client/src/views/action/record/panels/executions.js
+++ b/client/src/views/action/record/panels/executions.js
@@ -45,6 +45,8 @@ Espo.define('views/action/record/panels/executions', 'views/record/panels/relati
                 }
             ];
 
+            const filterableTypes = Object.keys(this.getMetadata().get('action.filterableTypes') ?? {});
+
             if (['create', 'createOrUpdate', 'createRendition'].includes(this.model.get('type'))) {
                 layout.push({
                     "name": "createdCount",
@@ -53,7 +55,7 @@ Espo.define('views/action/record/panels/executions', 'views/record/panels/relati
                 });
             }
 
-            if (['update', 'createOrUpdate'].includes(this.model.get('type'))) {
+            if (['update', 'createOrUpdate', ...filterableTypes].includes(this.model.get('type'))) {
                 layout.push({
                     "name": "updatedCount",
                     "notSortable": true,
@@ -61,7 +63,7 @@ Espo.define('views/action/record/panels/executions', 'views/record/panels/relati
                 });
             }
 
-            if (['create', 'update', 'createOrUpdate', 'createRendition'].includes(this.model.get('type'))) {
+            if (['create', 'update', 'createOrUpdate', 'createRendition', ...filterableTypes].includes(this.model.get('type'))) {
                 layout.push({
                     "name": "failedCount",
                     "notSortable": true,


### PR DESCRIPTION
…dynamic where clauses, and rework retry scheduling as Action-driven jobs

Update::useMassActions() now detects when the where clause is templated per triggering entity ({{ entity.* }}) and routes execution through the per-entity mass-action loop instead of a single combined query. ScheduledJob gains Action-backed job execution (Jobs/Action, ActionHandler) to run retry/report actions on a schedule.