### PR TITLE
Simplify Action execution status handling and clean up Action layout

### DIFF
--- a/app/Atro/ActionTypes/AbstractAction.php
+++ b/app/Atro/ActionTypes/AbstractAction.php
@@ -148,25 +148,10 @@ abstract class AbstractAction implements TypeInterface
     {
         // for backward compatibility
         if (method_exists($this, 'executeNow')) {
-            $action = $execution->get('action');
-            try {
-                $res = $this->executeNow($action, $input);
-                $execution->set('status', 'done');
-            } catch (\Throwable $e) {
-                $res = false;
-                $execution->set('status', 'failed');
-                $execution->set('statusMessage', $e->getMessage());
+            $res = $this->executeNow($execution->get('action'), $input);
 
-                if ($e instanceof BadRequest && $action->get('type') === 'error') {
-                    $res = true;
-                    $execution->set('status', 'done');
-                }
-            }
+            $execution->set('status', 'done');
             $this->getEntityManager()->saveEntity($execution);
-
-            if (!empty($e) && empty($res)) {
-                throw $e;
-            }
 
             return $res;
         }

--- a/app/Atro/Core/ActionManager.php
+++ b/app/Atro/Core/ActionManager.php
@@ -12,6 +12,7 @@
 namespace Atro\Core;
 
 use Atro\ActionTypes\TypeInterface;
+use Atro\Core\Exceptions\BadRequest;
 use Atro\Core\Exceptions\Error;
 use Atro\Core\KeyValueStorages\MemoryStorage;
 use Atro\Core\Utils\Metadata;
@@ -160,9 +161,12 @@ class ActionManager
             $res = $actionType->execute($execution, $input);
         } catch (\Throwable $e) {
             $res = false;
-            $execution->set('status', 'failed');
-            $execution->set('statusMessage', $e->getMessage());
-            $this->getEntityManager()->saveEntity($execution);
+
+            if (!($e instanceof BadRequest && $action->get('type') === 'error')) {
+                $execution->set('status', 'failed');
+                $execution->set('statusMessage', $e->getMessage());
+                $this->getEntityManager()->saveEntity($execution);
+            }
         }
 
         if ($userChanged) {

--- a/app/Atro/Listeners/ActionLayout.php
+++ b/app/Atro/Listeners/ActionLayout.php
@@ -39,13 +39,4 @@ class ActionLayout extends AbstractLayoutListener
             $event->setArgument('result', $result);
         }
     }
-
-    public function relationships(Event $event): void
-    {
-        $result = $event->getArgument('result');
-
-        $result[] = ['name' => 'actions'];
-
-        $event->setArgument('result', $result);
-    }
 }

--- a/app/Atro/Resources/layouts/Action/relationships.json
+++ b/app/Atro/Resources/layouts/Action/relationships.json
@@ -1,5 +1,8 @@
 [
   {
+    "name": "actions"
+  },
+  {
     "name": "entityFilterResult"
   },
   {


### PR DESCRIPTION
ActionManager now skips overwriting an execution's status/statusMessage when it's a BadRequest thrown by an 'error'-type action, since that action already records its own outcome. AbstractAction's executeNow() backward compatibility shim no longer duplicates that failure handling - it just adapts the legacy signature and marks the execution done on success, letting any exception propagate to ActionManager's single catch.

Also moves the Action "actions" relationship panel registration from a listener method into the static relationships layout file.