### PR TITLE
Skip name-collision validation and rebuild for unsynced local storages

### DIFF
--- a/app/Atro/Console/RefreshStoragesItems.php
+++ b/app/Atro/Console/RefreshStoragesItems.php
@@ -26,33 +26,43 @@ class RefreshStoragesItems extends AbstractConsole
 
     public function run(array $data): void
     {
-        $this->createFoldersItems();
-        self::show("Folders items has been refreshed successfully.", self::SUCCESS);
+        try {
+            $this->createFoldersItems();
+            self::show("Folders items has been refreshed successfully.", self::SUCCESS);
 
-        $this->createFilesItems();
-        self::show("Files items has been refreshed successfully.", self::SUCCESS);
+            $this->createFilesItems();
+            self::show("Files items has been refreshed successfully.", self::SUCCESS);
+
+        } catch (\Throwable $e) {
+            self::show($e->getMessage(), self::ERROR);
+        }
     }
 
     public function createFoldersItems(): void
     {
-        $this->getConnection()->createQueryBuilder()
+        $this->getDbal()->createQueryBuilder()
             ->delete('file_folder_linker')
             ->where('folder_id IS NOT NULL')
             ->executeQuery();
 
-        $records = $this->getConnection()->createQueryBuilder()
+        $records = $this->getDbal()->createQueryBuilder()
             ->select('f.*, h.parent_id')
             ->from('folder', 'f')
+            ->innerJoin('f', 'storage', 's', 'f.storage_id=s.id')
             ->leftJoin('f', 'folder_hierarchy', 'h', 'f.id=h.entity_id')
             ->leftJoin('h', 'folder', 'f1', 'f1.id=h.parent_id')
             ->where('f.deleted=:false')
             ->andWhere('f.deleted=:false')
             ->andWhere('f1.deleted=:false')
+            ->andWhere('s.deleted=:false')
+            ->andWhere('(s.type != :local OR s.sync_folders = :true)')
             ->setParameter('false', false, ParameterType::BOOLEAN)
+            ->setParameter('true', true, ParameterType::BOOLEAN)
+            ->setParameter('local', 'local')
             ->fetchAllAssociative();
 
         foreach ($records as $record) {
-            $this->getConnection()->createQueryBuilder()
+            $this->getDbal()->createQueryBuilder()
                 ->insert('file_folder_linker')
                 ->setValue('id', ':id')
                 ->setValue('name', ':name')
@@ -68,22 +78,25 @@ class RefreshStoragesItems extends AbstractConsole
 
     public function createFilesItems(): void
     {
-        $this->getConnection()->createQueryBuilder()
+        $this->getDbal()->createQueryBuilder()
             ->delete('file_folder_linker')
             ->where('file_id IS NOT NULL')
             ->executeQuery();
 
-        $records = $this->getConnection()->createQueryBuilder()
+        $records = $this->getDbal()->createQueryBuilder()
             ->select('f.*, s.path as storage_path')
             ->from('file', 'f')
             ->innerJoin('f', 'storage', 's', 'f.storage_id=s.id')
             ->where('f.deleted=:false')
             ->andWhere('s.deleted=:false')
+            ->andWhere('(s.type != :local OR s.sync_folders = :true)')
             ->setParameter('false', false, ParameterType::BOOLEAN)
+            ->setParameter('true', true, ParameterType::BOOLEAN)
+            ->setParameter('local', 'local')
             ->fetchAllAssociative();
 
         foreach ($records as $record) {
-            $this->getConnection()->createQueryBuilder()
+            $this->getDbal()->createQueryBuilder()
                 ->insert('file_folder_linker')
                 ->setValue('id', ':id')
                 ->setValue('name', ':name')
@@ -97,8 +110,8 @@ class RefreshStoragesItems extends AbstractConsole
         }
     }
 
-    protected function getConnection(): Connection
+    protected function getDbal(): Connection
     {
-        return $this->getContainer()->get('connection');
+        return $this->getContainer()->get('dbal');
     }
 }

--- a/app/Atro/Repositories/File.php
+++ b/app/Atro/Repositories/File.php
@@ -418,6 +418,15 @@ class File extends Base
 
     public function validateItemName(FileEntity $file): void
     {
+        $storage = $file->getStorage();
+        if (empty($storage)) {
+            return;
+        }
+
+        if ($storage->get('type') === 'local' && empty($storage->get('syncFolders'))) {
+            return;
+        }
+
         if ($file->isNew() || $file->isAttributeChanged('name') || $file->isAttributeChanged('folderId')) {
             $qb = $this->getDbal()->createQueryBuilder()
                 ->select('*')
@@ -427,7 +436,7 @@ class File extends Base
                 ->andWhere('deleted = :false')
                 ->setParameter('name', $file->get('name'))
                 ->setParameter('parentId', $file->get('folderId') ?? '')
-                ->setParameter('false', 'false', ParameterType::BOOLEAN);
+                ->setParameter('false', false, ParameterType::BOOLEAN);
 
             if (!$file->isNew()) {
                 $qb->andWhere('id!=:id')->setParameter('id', $file->get('id'));


### PR DESCRIPTION
File name-uniqueness validation and the storages-items rebuild console command now skip local storages that don't have "Sync Folders/Files" enabled, matching the existing guard already used when creating/updating file_folder_linker rows.