### PR TITLE
Fix attribute values being unlinked right after import sets them

### DIFF
--- a/app/Atro/Repositories/Attribute.php
+++ b/app/Atro/Repositories/Attribute.php
@@ -393,6 +393,11 @@ class Attribute extends Base
             $value = $entity->entityDefs['fields'][$fieldName]['default'];
         }
 
+        $idField = lcfirst($entity->getEntityName()) . 'AttributeValuesIds';
+        if ($entity->has($idField)) {
+            $entity->clear($idField);
+        }
+
         if (!$this->getAcl()->check($entity->getEntityName(), 'createAttributeValue')) {
             if ($insertOnly) {
                 return;


### PR DESCRIPTION
Root cause: when an import row contains any "...AddOnlyMode" flag (set by Import\FieldConverters\LinkMultiple/JsonArray whenever the "Replace" option is off), RecordService::prepareInputForAddOnlyMode() calls $this->getEntity($id) to merge new values with existing ones.

For Hierarchy-based entities (e.g. Product) this call resolves to Hierarchy::getEntity(), which runs getInheritedFields() -> getInheritedFromParentFields(). For the generic "{scope}AttributeValues" link (registered by Metadata::addAttributesToEntity(), which has no "attributeId" in its field defs, unlike the per-attribute dynamic fields), that method calls Entity::getLinkMultipleIdList(), a read-oriented helper that lazily loads the field and, as a side effect, permanently sets "{scope}AttributeValuesIds" on the entity with whatever was linked *before* this request's own attribute upserts run.

The entity instance being read here is the same memoryStorage-cached object that updateEntity() later saves, so this side effect survives until save time. Atro\Core\ORM\Repositories\RDB::processSpecifiedRelationsSave() (an afterSave hook) then sees entity->has("{scope}AttributeValuesIds") as true and treats that stale snapshot as the complete desired relation state, unrelating (nulling the product_id FK of) every product_attribute_value row not present in it - including the row that was just correctly written earlier in the very same request. This is why a "Relate" Note is created, but the attribute value never actually shows up on the record.

Fix: clear "{scope}AttributeValuesIds" at the start of upsertAttributeValue(), which fires for every attribute value that is actually changed during the save. This runs after the pollution described above and before processSpecifiedRelationsSave(), so the relation is left untouched by the afterSave reconciliation for any save that writes an attribute value.