### PR TITLE
Add per-field default merge selection and distinct conflict message t…

### DIFF
--- a/app/Atro/Resources/i18n/en_US/Global.json
+++ b/app/Atro/Resources/i18n/en_US/Global.json
@@ -680,7 +680,8 @@
     "theSavedFilterMightBeCorrupt": "Format not supported, the Saved Filter might be corrupt.",
     "closePanelConfirmation": "Are you sure you want to close the panel?",
     "minimumRecordForComparison": "You cannot have less than {count} records.",
-    "notPossibleToOpenDetailView": "It is not possible to open the detail view."
+    "notPossibleToOpenDetailView": "It is not possible to open the detail view.",
+    "resolveMergeConflictsBeforeMerging": "Some fields are in conflict, please choose a value for them before merging."
   },
   "boolFilters": {
     "onlyActive": "Active",

--- a/client/src/views/record/compare.js
+++ b/client/src/views/record/compare.js
@@ -200,6 +200,11 @@ Espo.define('views/record/compare', ['view', 'views/record/list', 'collection'],
             for (const panel of this.fieldPanels) {
                 let fieldsPanels = this.getView(panel.name);
 
+                if (fieldsPanels.getUnresolvedFields().length > 0) {
+                    this.notify(this.translate('resolveMergeConflictsBeforeMerging', 'messages'), 'error');
+                    return;
+                }
+
                 if (fieldsPanels.validate()) {
                     this.notify(this.translate('fillEmptyFieldBeforeMerging', 'messages'), 'error');
                     return;
@@ -491,8 +496,10 @@ Espo.define('views/record/compare', ['view', 'views/record/list', 'collection'],
                     instances: this.instances,
                     columns: this.buildComparisonTableHeaderColumn(),
                     instanceComparison: this.instanceComparison,
+                    derivativeComparison: this.options.derivativeComparison,
                     models: this.getModels(),
                     defaultModelId: this.getDefaultModelId(),
+                    getDefaultModelIdForField: (field) => this.getDefaultModelIdForField(field),
                     merging: this.merging,
                     hideCheckAll: index !== 0,
                     hasLayoutEditor: !!panel.hasLayoutEditor,
@@ -538,6 +545,16 @@ Espo.define('views/record/compare', ['view', 'views/record/list', 'collection'],
 
         getDefaultModelId() {
             return this.getModels()[0].id;
+        },
+
+        /**
+         * Per-field default model id for merge mode. Returns null when there is no default
+         * (e.g. a conflict that must be explicitly resolved by the user) - no column is
+         * pre-selected in that case. Falls back to the single whole-column default so every
+         * other consumer of this generic compare view is unaffected.
+         */
+        getDefaultModelIdForField(field) {
+            return this.getDefaultModelId();
         },
 
         renderRelationshipsPanels() {

--- a/client/src/views/record/compare/fields-panels.js
+++ b/client/src/views/record/compare/fields-panels.js
@@ -36,6 +36,7 @@ Espo.define('views/record/compare/fields-panels', 'view', function (Dep) {
             this.model = this.options.model;
             this.instances = this.options.instances ?? this.getMetadata().get(['app', 'comparableInstances'])
             this.instanceComparison = this.options.instanceComparison;
+            this.derivativeComparison = this.options.derivativeComparison;
             this.columns = this.options.columns;
             this.models = this.options.models;
             this.merging = this.options.merging;
@@ -84,10 +85,12 @@ Espo.define('views/record/compare/fields-panels', 'view', function (Dep) {
             this.fieldList.forEach(fieldListByGroup => {
                 fieldListByGroup.fieldListInGroup.forEach(fieldData => {
                     let field = fieldData.field;
+                    let defaultModelId = this.getDefaultModelIdForField(field);
+
                     fieldData.fieldValueRows.forEach((row, index) => {
                         let model = this.models[index];
                         let viewName = model.getFieldParam(field, 'view') || this.getFieldManager().getViewName(fieldData.type);
-                        let mode = (this.merging && index === 0 && !fieldData.disabled) ? 'edit' : 'detail';
+                        let mode = (this.merging && model.id === defaultModelId && !fieldData.disabled) ? 'edit' : 'detail';
                         let modelForView = model;
                         if (this.merging) {
                             modelForView = model.clone();
@@ -183,8 +186,36 @@ Espo.define('views/record/compare/fields-panels', 'view', function (Dep) {
         afterRender() {
             Dep.prototype.afterRender.call(this)
             if (this.merging) {
-                $('input[data-id="' + this.options.defaultModelId + '"]').prop('checked', true);
+                if (this.derivativeComparison) {
+                    // conflict-aware, per-field default selection (see getDefaultModelIdForField) -
+                    // the "select this whole column" header radio still lives outside this panel's
+                    // own tbody (in compare.tpl's thead), so it always uses the standard default
+                    $('input[type="radio"][name="check-all"][data-id="' + this.options.defaultModelId + '"]').prop('checked', true);
+
+                    this.fieldList.forEach(fieldListByGroup => {
+                        fieldListByGroup.fieldListInGroup.forEach(fieldData => {
+                            let defaultModelId = this.getDefaultModelIdForField(fieldData.field);
+                            if (defaultModelId) {
+                                this.$el.find(`input.field-radio[name="${fieldData.field}"][data-id="${defaultModelId}"]`).prop('checked', true);
+                            }
+                        });
+                    });
+                } else {
+                    $('input[data-id="' + this.options.defaultModelId + '"]').prop('checked', true);
+                }
             }
+        },
+
+        /**
+         * Resolves per-field via options.getDefaultModelIdForField when provided (returns null
+         * for "no default", e.g. an unresolved conflict - no column gets pre-selected), otherwise
+         * falls back to the single whole-panel default id every other caller still passes.
+         */
+        getDefaultModelIdForField(field) {
+            if (typeof this.options.getDefaultModelIdForField === 'function') {
+                return this.options.getDefaultModelIdForField(field);
+            }
+            return this.options.defaultModelId;
         },
 
         handleAllFieldsRendered(key) {
@@ -319,6 +350,29 @@ Espo.define('views/record/compare/fields-panels', 'view', function (Dep) {
             });
 
             return validate;
+        },
+
+        /**
+         * Fields with no checked radio at all - i.e. unresolved merge conflicts (see
+         * getDefaultModelIdForField(), which returns null for those). Kept separate from
+         * validate() so the caller can show a distinct "resolve conflicts" message instead of
+         * the generic "fill required fields" one.
+         */
+        getUnresolvedFields() {
+            let unresolved = [];
+
+            this.fieldList.forEach(fieldListByGroup => {
+                fieldListByGroup.fieldListInGroup.forEach(fieldData => {
+                    if (fieldData.disabled) {
+                        return;
+                    }
+                    if (this.$el.find(`input.field-radio[name="${fieldData.field}"]:checked`).length === 0) {
+                        unresolved.push(fieldData.field);
+                    }
+                });
+            });
+
+            return unresolved;
         }
     })
 })


### PR DESCRIPTION
…o compare view

Generalizes the compare/merge view's single whole-column default into a per-field one (getDefaultModelIdForField), with a null default meaning an unresolved conflict that blocks merging with its own message instead of the generic required-field one. Scoped to derivative (change-request) comparisons only; every other merge consumer keeps its original behavior unchanged.